### PR TITLE
Added method to find one gene for 'approved' symbol

### DIFF
--- a/api/src/main/scala/de/bwhc/catalogs/hgnc/HGNC.scala
+++ b/api/src/main/scala/de/bwhc/catalogs/hgnc/HGNC.scala
@@ -84,6 +84,17 @@ trait HGNCCatalog[F[_]]
         .toList
       )
 
+  /**
+   * Returns one [[Option]] of [[HGNCGene]] for 'approved' symbol ignoring ambiguous 'previous/alias symbol'
+   * @param sym The symbol name
+   * @return The HGNCGene or empty Option
+   */
+  def geneWithApprovedSymbol(sym: String)(implicit F: Applicative[F]): F[Option[HGNCGene]] =
+    self.genes
+      .map(
+        _.find(_.symbol.equalsIgnoreCase(sym))
+      )
+
   def geneWithName(name: String)(implicit F: Applicative[F]): F[Option[HGNCGene]] =
     self.genes
       .map(_.find(_.name.equalsIgnoreCase(name)))

--- a/tests/src/test/scala/de/bwhc/hgnc/test/Tests.scala
+++ b/tests/src/test/scala/de/bwhc/hgnc/test/Tests.scala
@@ -35,6 +35,29 @@ class Tests extends AnyFlatSpec
     
   }
 
+  it should "contain one match with HGNC-ID 'HGNC:11998'" in {
+
+    assert(hgnc.genesMatchingSymbol("TP53").exists(_.hgncId == HGNCId("HGNC:11998")))
+
+  }
+
+  it should "find one gene for approved symbol 'TP53' with HGNC-ID 'HGNC:11998'" in {
+
+    assert(hgnc.geneWithApprovedSymbol("TP53").exists(_.hgncId == HGNCId("HGNC:11998")))
+
+  }
+
+  it should "find one gene for approved symbol 'tp53' (lower case) with HGNC-ID 'HGNC:11998'" in {
+
+    assert(hgnc.geneWithApprovedSymbol("tp53").exists(_.hgncId == HGNCId("HGNC:11998")))
+
+  }
+
+  it should "return empty result for gene with not applicable symbol 'someuselesstestsymbol'" in {
+
+    assert(hgnc.geneWithApprovedSymbol("someuselesstestsymbol").isEmpty)
+
+  }
 
   it should "contain 5 alias symbols for Gene with HGNC-ID 'HGNC:24086'" in {
 


### PR DESCRIPTION
This method acts like `geneWithSymbol()` but ignores ambiguous previous or alias symbols in gene data and will return only one or no gene.

This can be used to find related gene information to complete exported bwHC/DNPM data within [Variants.scala](https://github.com/KohlbacherLab/bwHC-Data-Validation-Service/blob/master/api/src/main/scala/de/bwhc/mtb/data/entry/dtos/Variants.scala) using _Symbol_ in addition to _HGNC-ID_/_Ensembl-ID_.